### PR TITLE
Debug/memory - Overall Still memory from exit function

### DIFF
--- a/include/EpollPoller.hpp
+++ b/include/EpollPoller.hpp
@@ -4,6 +4,7 @@
 #ifdef __linux__
 
 #include "Define.hpp"
+#include "Log.hpp"
 #include "Poller.hpp"
 #include <cerrno>
 #include <cstdio>
@@ -28,7 +29,7 @@ class EpollPoller : public Poller
   private:
     int _epoll_fd;
     // _changes will act like the temporary changes array similar to KqueuePoller's 'changes'
-    std::vector<struct epoll_event> _changes;
+    struct epoll_event _events[MAX_EVENTS];
 };
 
 #endif

--- a/include/KqueuePoller.hpp
+++ b/include/KqueuePoller.hpp
@@ -4,6 +4,7 @@
 #ifdef __APPLE__
 
 #include "Define.hpp"
+#include "Log.hpp"
 #include "Poller.hpp"
 #include <cstdlib>
 #include <cstring>

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -19,6 +19,7 @@
 #include <csignal>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -39,7 +40,7 @@ class Server
 
     // private 멤버 변수에 언더바 접두사 추가
     std::vector<ServerConfig> _server_configs;
-    Poller *_poller;
+    std::auto_ptr<Poller> _poller;
     std::map<int, std::string> _partialRequests;
     std::map<int, std::string> _outgoingData;
     std::map<int, Request> _requestMap;

--- a/src/Poller/EpollPoller.cpp
+++ b/src/Poller/EpollPoller.cpp
@@ -5,23 +5,19 @@
 #include "Utils.hpp" // for intToString
 #include <sys/epoll.h>
 
-EpollPoller::EpollPoller() : _changes()
+EpollPoller::EpollPoller()
 {
     _epoll_fd = epoll_create1(0);
     if (_epoll_fd == -1)
     {
-        std::cerr << "epoll_create1 failed: " << strerror(errno) << std::endl;
-        exit(EXIT_FAILURE);
+        std::string errMsg = "epoll_create1 failed: " + std::string(strerror(errno));
+        throw std::runtime_error(errMsg);
     }
-    // Reserve space for change events similar to Kqueue's fixed array size.
-    _changes.resize(MAX_EVENTS);
 }
 
 EpollPoller::~EpollPoller()
 {
     close(_epoll_fd);
-    _changes.clear();
-    std::vector<struct epoll_event>().swap(_changes);
 }
 
 bool EpollPoller::add(int fd, uint32_t events)
@@ -36,7 +32,8 @@ bool EpollPoller::add(int fd, uint32_t events)
 
     if (epoll_ctl(_epoll_fd, EPOLL_CTL_ADD, fd, &ev) == -1)
     {
-        std::cerr << "epoll_ctl add failed for fd " << intToString(fd) << ": " << strerror(errno) << std::endl;
+        std::string errMsg = "epoll_ctl add failed for fd " + intToString(fd) + ": " + std::string(strerror(errno));
+        LogConfig::reportInternalError(errMsg);
         return false;
     }
     return true;
@@ -54,7 +51,8 @@ bool EpollPoller::modify(int fd, uint32_t events)
 
     if (epoll_ctl(_epoll_fd, EPOLL_CTL_MOD, fd, &ev) == -1)
     {
-        std::cerr << "epoll_ctl modify failed for fd " << intToString(fd) << ": " << strerror(errno) << std::endl;
+        std::string errMsg = "epoll_ctl modify failed for fd " + intToString(fd) + ": " + std::string(strerror(errno));
+        LogConfig::reportInternalError(errMsg);
         return false;
     }
     return true;
@@ -64,7 +62,8 @@ bool EpollPoller::remove(int fd)
 {
     if (epoll_ctl(_epoll_fd, EPOLL_CTL_DEL, fd, NULL) == -1)
     {
-        std::cerr << "epoll_ctl remove failed for fd " << intToString(fd) << ": " << strerror(errno) << std::endl;
+        std::string errMsg = "epoll_ctl remove failed for fd " + intToString(fd) + ": " + std::string(strerror(errno));
+        LogConfig::reportInternalError(errMsg);
         return false;
     }
     return true;
@@ -72,43 +71,43 @@ bool EpollPoller::remove(int fd)
 
 int EpollPoller::poll(std::vector<Event> &events_out, int timeout)
 {
-    // Create a temporary array for epoll_wait
-    struct epoll_event events[MAX_EVENTS];
-    int nevents = epoll_wait(_epoll_fd, events, MAX_EVENTS, timeout);
+    int nevents = epoll_wait(_epoll_fd, _events, MAX_EVENTS, timeout);
     if (nevents == -1)
     {
         if (errno == EINTR)
             return 0;
-        std::cerr << "epoll_wait failed: " << strerror(errno) << std::endl;
+        std::string errMsg = "epoll_wait failed: " + std::string(strerror(errno));
+        LogConfig::reportInternalError(errMsg);
         return -1;
     }
     events_out.clear();
     for (int i = 0; i < nevents; ++i)
     {
-        if (events[i].events & EPOLLERR)
+        if (_events[i].events & EPOLLERR)
         {
             int err = 0;
             socklen_t len = sizeof(err);
-            if (getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0)
+            if (getsockopt(_events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0)
             {
-                std::cerr << "epoll event error on fd " << intToString(events[i].data.fd) << ": " << strerror(err)
-                          << std::endl;
+                std::string errMsg =
+                    "epoll event error on fd " + intToString(_events[i].data.fd) + ": " + std::string(strerror(err));
+                LogConfig::reportInternalError(errMsg);
             }
             else
             {
-                std::cerr << "epoll event error on fd " << intToString(events[i].data.fd) << ": unable to get error"
-                          << std::endl;
+                std::string errMsg =
+                    "epoll event error on fd " + intToString(_events[i].data.fd) + ": unable to get error";
+                LogConfig::reportInternalError(errMsg);
             }
-            // 연결이 리셋되었으므로 해당 fd를 epoll에서 제거합니다.
-            remove(events[i].data.fd);
+            remove(_events[i].data.fd);
             continue;
         }
         Event ev;
-        ev.fd = events[i].data.fd;
+        ev.fd = _events[i].data.fd;
         ev.events = 0;
-        if (events[i].events & EPOLLIN)
+        if (_events[i].events & EPOLLIN)
             ev.events |= POLLER_READ;
-        if (events[i].events & EPOLLOUT)
+        if (_events[i].events & EPOLLOUT)
             ev.events |= POLLER_WRITE;
         events_out.push_back(ev);
     }

--- a/src/Poller/EpollPoller.cpp
+++ b/src/Poller/EpollPoller.cpp
@@ -77,6 +77,8 @@ int EpollPoller::poll(std::vector<Event> &events_out, int timeout)
     int nevents = epoll_wait(_epoll_fd, events, MAX_EVENTS, timeout);
     if (nevents == -1)
     {
+        if (errno == EINTR)
+            return 0;
         std::cerr << "epoll_wait failed: " << strerror(errno) << std::endl;
         return -1;
     }

--- a/src/Server/ServerCore.cpp
+++ b/src/Server/ServerCore.cpp
@@ -31,7 +31,7 @@ Server::Server(const std::string &configFile) : _poller(NULL)
     if (!config.parseConfigFile(configFile))
     {
         LogConfig::reportInternalError("Failed to parse configuration file.");
-        exit(EXIT_FAILURE);
+        throw std::runtime_error("Failed to parse configuration file.");
     }
     show_ascii();
     _server_configs = config.servers;

--- a/src/Server/ServerCore.cpp
+++ b/src/Server/ServerCore.cpp
@@ -35,10 +35,11 @@ Server::Server(const std::string &configFile) : _poller(NULL)
     }
     show_ascii();
     _server_configs = config.servers;
+// _poller를 임시 auto_ptr로 생성하여 RAII를 적용합니다.
 #ifdef __linux__
-    _poller = new EpollPoller();
+    _poller = std::auto_ptr<Poller>(new EpollPoller());
 #elif defined(__APPLE__)
-    _poller = new KqueuePoller();
+    _poller = std::auto_ptr<Poller>(new KqueuePoller());
 #else
 #error "Unsupported OS"
 #endif

--- a/src/Server/ServerCore.cpp
+++ b/src/Server/ServerCore.cpp
@@ -55,7 +55,6 @@ Server::~Server()
             close(_server_configs[i].server_sockets[j]);
         }
     }
-    delete _poller;
     std::map<int, std::string>().swap(_partialRequests);
     std::map<int, std::string>().swap(_outgoingData);
     std::map<int, Request>().swap(_requestMap);

--- a/src/Server/ServerWrite.cpp
+++ b/src/Server/ServerWrite.cpp
@@ -11,11 +11,11 @@ void Server::writePendingData(int client_fd)
     if (closed_fds.find(client_fd) != closed_fds.end())
         return;
     std::string &buf = _outgoingData[client_fd];
-    if (!writePendingDataHelper(_poller, client_fd, buf))
+    if (!writePendingDataHelper(_poller.get(), client_fd, buf))
     {
         safelyCloseClient(client_fd);
         _outgoingData.erase(client_fd);
-        //closed_fds.insert(client_fd);
+        // closed_fds.insert(client_fd);
         return;
     }
     if (!buf.empty())
@@ -25,12 +25,12 @@ void Server::writePendingData(int client_fd)
         if (!_poller->modify(client_fd, POLLER_READ))
         {
             if (errno != ENOENT)
-            // 만약 errno가 ENOENT이면 이미 제거된 것으로 간주하고 무시할 수 있습니다.
+                // 만약 errno가 ENOENT이면 이미 제거된 것으로 간주하고 무시할 수 있습니다.
                 LogConfig::reportInternalError("writePendingData: Failed to reset to READ event for client_fd " +
                                                intToString(client_fd));
             safelyCloseClient(client_fd);
             _outgoingData.erase(client_fd);
-            //closed_fds.insert(client_fd);
+            // closed_fds.insert(client_fd);
         }
     }
     else

--- a/src/Server/SocketManager.cpp
+++ b/src/Server/SocketManager.cpp
@@ -5,8 +5,9 @@ int SocketManager::createSocket(int port)
     int sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0)
     {
-        LogConfig::reportInternalError("socket() failed for port " + intToString(port));
-        exit(EXIT_FAILURE);
+        std::string errMsg = "socket() failed for port " + intToString(port);
+        LogConfig::reportInternalError(errMsg);
+        throw std::runtime_error(errMsg);
     }
     return sockfd;
 }
@@ -17,15 +18,17 @@ void SocketManager::setSocketNonBlocking(int sockfd, int port)
     int flags = fcntl(sockfd, F_GETFL, 0);
     if (flags == -1)
     {
-        LogConfig::reportInternalError("fcntl(F_GETFL) failed: " + std::string(strerror(errno)));
+        std::string errMsg = "fcntl(F_GETFL) failed: " + std::string(strerror(errno));
+        LogConfig::reportInternalError(errMsg);
         close(sockfd);
-        exit(EXIT_FAILURE);
+        throw std::runtime_error(errMsg);
     }
     if (fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) == -1)
     {
-        LogConfig::reportInternalError("fcntl(F_SETFL) failed: " + std::string(strerror(errno)));
+        std::string errMsg = "fcntl(F_SETFL) failed: " + std::string(strerror(errno));
+        LogConfig::reportInternalError(errMsg);
         close(sockfd);
-        exit(EXIT_FAILURE);
+        throw std::runtime_error(errMsg);
     }
 }
 
@@ -39,12 +42,12 @@ void SocketManager::bindSocket(int sockfd, int port)
 
     if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
     {
-        std::string errorMsg = "bind() failed for port " + intToString(port) + ": " + strerror(errno);
+        std::string errMsg = "bind() failed for port " + intToString(port) + ": " + strerror(errno);
         if (errno == EADDRINUSE)
-            errorMsg += " (Port already in use)";
-        LogConfig::reportInternalError(errorMsg);
+            errMsg += " (Port already in use)";
+        LogConfig::reportInternalError(errMsg);
         close(sockfd);
-        exit(EXIT_FAILURE);
+        throw std::runtime_error(errMsg);
     }
 }
 
@@ -52,9 +55,10 @@ void SocketManager::startListening(int sockfd, int port)
 {
     if (listen(sockfd, SOMAXCONN) < 0)
     {
-        LogConfig::reportInternalError("listen() failed for port " + intToString(port) + ": " + strerror(errno));
+        std::string errMsg = "listen() failed for port " + intToString(port) + ": " + strerror(errno);
+        LogConfig::reportInternalError(errMsg);
         close(sockfd);
-        exit(EXIT_FAILURE);
+        throw std::runtime_error(errMsg);
     }
 }
 


### PR DESCRIPTION
## webserv PR message template and checklist.
Please fill in/check all the items below and PR!

## Brief one-line summary of the fix
(Please write a short one-line summary/title of your fix here).
- Add EINTR error hanlding in poll() for gracefull shutdown
- Add runtime_error against exit() for still reachable memory when getting fail of parsing config
- KqueuePoller and EpollPoller functions to use stack memory instead of heap memory
- Leveraging RAII techniques to safely free dynamically allocated memory on exception in server function
- Use _poller.get() instead of _poller for arguments to writePendingDataHelper due to smart pointer usage
		 
## Detailed description of the fix
(Please write more details about your fix here)
- Implemetned feature for parsing capitalization

## Other questions
(Feel free to write any questions you have, things you noticed along the way, or anything else you want to share).
- The function logic seems to be too long, I wonder if there is a more efficient way to do it.(Example) 


## What's Next
- Write what's Next here

## CheckList
- [x] Check and follow the rules stated above
- [x] You have completed the necessary tests and verified that the functionality works properly.
- [x] You have written the code according to norminette.